### PR TITLE
PBKDF2 support

### DIFF
--- a/lib/devise/encryptable/encryptable.rb
+++ b/lib/devise/encryptable/encryptable.rb
@@ -21,6 +21,7 @@ module Devise
       autoload :RestfulAuthenticationSha1, 'devise/encryptable/encryptors/restful_authentication_sha1'
       autoload :Sha1, 'devise/encryptable/encryptors/sha1'
       autoload :Sha512, 'devise/encryptable/encryptors/sha512'
+      autoload :Pbkdf2, 'devise/encryptable/encryptors/pbkdf2'
     end
   end
 end

--- a/lib/devise/encryptable/encryptors/pbkdf2.rb
+++ b/lib/devise/encryptable/encryptors/pbkdf2.rb
@@ -1,0 +1,19 @@
+begin
+  require "pbkdf2"
+
+  module Devise
+    module Encryptable
+      module Encryptors
+        # = PBKDF2
+        # Uses the PBKDF2 algorithm to encrypt passwords.
+        class Pbkdf2 < Base
+          def self.digest(password, stretches, salt, pepper)
+            ::PBKDF2.new(password: password, salt: "#{[salt].pack('H*')}#{pepper}", iterations: stretches, hash_function: 'sha1', key_length: 64).hex_string
+          end
+        end
+      end
+    end
+  end
+rescue LoadError
+  # Need pbkdf2 library installed to use this encryptor
+end


### PR DESCRIPTION
Add optional PBKDF2 encryptor that is available when the pbkdf2 gem is
installed.