### PR TITLE
Add PBKDF2 encryptor via OpenSSL::PKCS5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'devise', '~> 3.2.0'
+gem 'json', '~> 1.8.3'
 gem 'rails', '~> 4.2.0'
 gem 'sqlite3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       activesupport (>= 4.1.0)
     hike (1.2.3)
     i18n (0.7.0)
-    json (1.8.1)
+    json (1.8.3)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -123,6 +123,10 @@ PLATFORMS
 DEPENDENCIES
   devise (~> 3.2.0)
   devise-encryptable!
+  json (~> 1.8.3)
   mocha (= 1.0.0)
   rails (~> 4.2.0)
   sqlite3
+
+BUNDLED WITH
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ end
 
 And you're ready to go!
 
+## Configuration
+
+The `pbkdf2` encryptor uses a different algorithm than bcrypt to slow down its hashing mechanism and so the example
+values for `stretches` you might see in the Devise documentation will not apply to `pbkdf2`. You probably
+want a value like `100_000` rather than `10`.
+
 ## Contributing
 
 * Fork it

--- a/lib/devise/encryptable/encryptable.rb
+++ b/lib/devise/encryptable/encryptable.rb
@@ -6,7 +6,8 @@ module Devise
     :sha512 => 128,
     :clearance_sha1 => 40,
     :restful_authentication_sha1 => 40,
-    :authlogic_sha512 => 128
+    :authlogic_sha512 => 128,
+    :pbkdf2 => 128
   }
 
   # Used to define the password encryption algorithm.
@@ -21,6 +22,7 @@ module Devise
       autoload :RestfulAuthenticationSha1, 'devise/encryptable/encryptors/restful_authentication_sha1'
       autoload :Sha1, 'devise/encryptable/encryptors/sha1'
       autoload :Sha512, 'devise/encryptable/encryptors/sha512'
+      autoload :Pbkdf2, 'devise/encryptable/encryptors/pbkdf2'
     end
   end
 end

--- a/lib/devise/encryptable/encryptors/pbkdf2.rb
+++ b/lib/devise/encryptable/encryptors/pbkdf2.rb
@@ -1,0 +1,16 @@
+module Devise
+  module Encryptable
+    module Encryptors
+      class Pbkdf2 < Base
+        def self.digest(password, stretches, salt, pepper)
+          pepper ||= ''
+          password ||= ''
+          digest = OpenSSL::Digest::SHA512.new
+          len = digest.digest_length
+          iterations = stretches > 1000 ? stretches : 100_000
+          ::Digest::SHA512.hexdigest(OpenSSL::PKCS5.pbkdf2_hmac(pepper+password, salt, iterations, len, digest))
+        end
+      end
+    end
+  end
+end

--- a/test/devise/encryptable/encryptors_test.rb
+++ b/test/devise/encryptable/encryptors_test.rb
@@ -21,6 +21,12 @@ class Encryptors < ActiveSupport::TestCase
     assert_equal clearance, encryptor
   end
 
+  test 'should match a password created by pbkdf2' do
+    pbkdf2_hash = '2136f25eeafa8f530ce75ad457625ae7b494cb6d2038a86b30aff4caab20bfc8a59c9c89966c68c560410b60942636e1ba835c8bff7e1880e8af61a78d7c9405'
+    encryptor = Devise::Encryptable::Encryptors::Pbkdf2.digest('123mudar', 10, '48901d2b247a54088acb7f8ea3e695e50fe6791b', 'fee9a51ec0a28d11be380ca6dee6b4b760c1a3bf')
+    assert_equal pbkdf2_hash, encryptor
+  end
+
   test 'digest should raise NotImplementedError if not implemented in subclass' do
     c = Class.new(Devise::Encryptable::Encryptors::Base)
     assert_raise(NotImplementedError) do


### PR DESCRIPTION
**Why**: A strictly NIST/FIPS compliant encryptor.
