### PR TITLE
Add LDAP SSHA encryption method

### DIFF
--- a/lib/devise/encryptable/encryptable.rb
+++ b/lib/devise/encryptable/encryptable.rb
@@ -6,6 +6,7 @@ module Devise
     :sha512 => 128,
     :clearance_sha1 => 40,
     :restful_authentication_sha1 => 40,
+    :ldap_ssha => 38,
     :authlogic_sha512 => 128
   }
 
@@ -19,6 +20,7 @@ module Devise
       autoload :Base, 'devise/encryptable/encryptors/base'
       autoload :ClearanceSha1, 'devise/encryptable/encryptors/clearance_sha1'
       autoload :RestfulAuthenticationSha1, 'devise/encryptable/encryptors/restful_authentication_sha1'
+      autoload :LdapSsha, 'devise/encryptable/encryptors/ldap_ssha'
       autoload :Sha1, 'devise/encryptable/encryptors/sha1'
       autoload :Sha512, 'devise/encryptable/encryptors/sha512'
     end

--- a/lib/devise/encryptable/encryptors/ldap_ssha.rb
+++ b/lib/devise/encryptable/encryptors/ldap_ssha.rb
@@ -1,0 +1,28 @@
+require "digest/sha1"
+
+module Devise
+  module Encryptable
+    module Encryptors
+      # = Sha1
+      # Uses the Sha1 hash algorithm to encrypt passwords.
+      class LdapSsha < Base
+        # Generates a default password digest based on salt and the incoming password.
+        def self.digest(password, stretches, salt, pepper)
+          self.secure_digest(password, salt)
+        end
+
+        def self.salt(stretches)
+          Devise.friendly_token[0,4]
+        end
+
+        private
+
+        # Generate a SHA1 digest with salt
+        def self.secure_digest(password, salt)
+          raise "Invalid salt: #{salt}" if salt.size != 4
+          "{SSHA}" + Base64.encode64(Digest::SHA1.digest("#{password}#{salt}") + salt).strip
+        end
+      end
+    end
+  end
+end

--- a/test/devise/encryptable/encryptors_test.rb
+++ b/test/devise/encryptable/encryptors_test.rb
@@ -21,6 +21,12 @@ class Encryptors < ActiveSupport::TestCase
     assert_equal clearance, encryptor
   end
 
+  test 'should match a password created by LDAP SSHA' do
+    ldap = "{SSHA}SBHbzCOyVGhpEGiR3eXRuCVIEH0WK8EJ"
+    encryptor = Devise::Encryptable::Encryptors::LdapSsha.digest('123mudar', nil, "\x16+\xC1\t".force_encoding('ASCII-8BIT'), nil)
+    assert_equal ldap, encryptor
+  end
+
   test 'digest should raise NotImplementedError if not implemented in subclass' do
     c = Class.new(Devise::Encryptable::Encryptors::Base)
     assert_raise(NotImplementedError) do


### PR DESCRIPTION
This is the default algorithm used in OpenLDAP, it makes it easy to synchronize users database from devise to LDAP server.
