### PR TITLE
FIPs compatible

### DIFF
--- a/lib/devise/encryptable/encryptors/authlogic_sha512.rb
+++ b/lib/devise/encryptable/encryptors/authlogic_sha512.rb
@@ -1,4 +1,10 @@
-require "digest/sha2"
+begin
+  require 'openssl'
+  Object.send(:remove_const, :Digest)
+  Digest = OpenSSL::Digest
+rescue LoadError
+  require 'digest/sha2'
+end
 
 module Devise
   module Encryptable

--- a/lib/devise/encryptable/encryptors/clearance_sha1.rb
+++ b/lib/devise/encryptable/encryptors/clearance_sha1.rb
@@ -1,4 +1,10 @@
-require "digest/sha1"
+begin
+  require 'openssl'
+  Object.send(:remove_const, :Digest)
+  Digest = OpenSSL::Digest
+rescue LoadError
+  require "digest/sha1"
+end
 
 module Devise
   module Encryptable

--- a/lib/devise/encryptable/encryptors/restful_authentication_sha1.rb
+++ b/lib/devise/encryptable/encryptors/restful_authentication_sha1.rb
@@ -1,4 +1,10 @@
-require "digest/sha1"
+begin
+  require 'openssl'
+  Object.send(:remove_const, :Digest)
+  Digest = OpenSSL::Digest
+rescue LoadError
+  require 'digest/sha1'
+end
 
 module Devise
   module Encryptable

--- a/lib/devise/encryptable/encryptors/sha1.rb
+++ b/lib/devise/encryptable/encryptors/sha1.rb
@@ -1,4 +1,10 @@
-require "digest/sha1"
+begin
+  require 'openssl'
+  Object.send(:remove_const, :Digest)
+  Digest = OpenSSL::Digest
+rescue LoadError
+  require 'digest/sha1'
+end
 
 module Devise
   module Encryptable

--- a/lib/devise/encryptable/encryptors/sha512.rb
+++ b/lib/devise/encryptable/encryptors/sha512.rb
@@ -1,4 +1,10 @@
-require "digest/sha2"
+begin
+  require 'openssl'
+  Object.send(:remove_const, :Digest)
+  Digest = OpenSSL::Digest
+rescue LoadError
+  require 'digest/sha2'
+end
 
 module Devise
   module Encryptable


### PR DESCRIPTION
When ruby is built with openssl it uses openssl digests.
Calling Digest directly invokes alg##_Init which is disallowed in FIPs mode.
Reassign Digest to OpenSSL::Digest to use EVP interface